### PR TITLE
Fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
   },
   "description": "some js rest library",
   "devDependencies": {
-    "@types/node": "^14.14.9",
-    "@types/node-fetch": "^2.5.7"
+    "@types/node": "^14.14.9"
   },
   "files": [
     "lib/**/*"

--- a/src/request.ts
+++ b/src/request.ts
@@ -10,7 +10,6 @@ import fetch, {
   RequestInit,
   RequestRedirect,
 } from 'node-fetch';
-import { AbortSignal } from 'node-fetch/externals';
 
 import {
   HTTPHeaders,


### PR DESCRIPTION
node-fetch/externals is from @types/node-fetch which is a dev dependency so it throws an error by default, AbortSignal is already a global object in node so this is unnecessary anyways, if you want, you could also add @types/node-fetch as a normal dependency